### PR TITLE
[wooclap/moodle-mod_wooclap#11] upgrade fix

### DIFF
--- a/cli/v3_upgrade.php
+++ b/cli/v3_upgrade.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * CLI install steps for block my_external_backup_restore_courses
+ * for moodle course server side
+ *
+ * Notes:
+ *   - it is required to use the web server account when executing PHP CLI scripts
+ *   - you need to change the "www-data" to match the apache user account
+ *   - use "su" if "sudo" not available
+ *
+ * @package    block_my_external_backup_restore_courses
+ * @author 2021 Celine Perves cperves@unistra.fr
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+define('CLI_SCRIPT', true);
+
+require(__DIR__.'/../../../config.php');
+require_once("$CFG->libdir/clilib.php");
+require_once("$CFG->dirroot/mod/wooclap/locallib.php");
+
+// Now get cli options.
+list($options, $unrecognized) = cli_get_params(array('verbose' => false, 'help' => false), array('v' => 'verbose', 'h' => 'help'));
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    $help =
+        "perform v3 upgrade if not performed before
+
+Options:
+-v, --verbose         Print verbose progess information
+-h, --help            Print out this help
+
+Example:
+\$ sudo -u www-data /usr/bin/php /var/www/moodle/mod/wooclap/cli/v3_upgrade.php
+";
+
+    echo $help;
+    die;
+}
+
+if (empty($options['verbose'])) {
+    $trace = new null_progress_trace();
+} else {
+    $trace = new text_progress_trace();
+}
+
+$result = mod_wooclap_v3_upgrade();
+$trace->finished();
+
+exit($result);
+

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -94,10 +94,10 @@ function xmldb_wooclap_upgrade($oldversion) {
             echo $exc->getMessage();
         }
         // Check that plugin is configured.
-        if ( !empty($accesskeyid) && !empty($secretaccesskey)) {
+        if ( !empty($accesskeyid)) {
             mod_wooclap_v3_upgrade();
         } else {
-            $warn = "Access key and/or secret key are missing for Wooclap plugin. Then considering that plugin is not used. Remote Wooclap upgrade datas steps not executed.";
+            $warn = "Access key is missing for Wooclap plugin. Then considering that plugin is not configured and not  used. Remote Wooclap upgrade datas steps not executed.";
             echo $OUTPUT->notification($warn, 'notifyproblem');
         }
         // PART 2 of the V3 upgrade.

--- a/locallib.php
+++ b/locallib.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+// More info: https://docs.moodle.org/dev/Upgrade_API .
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Perform v3 upgrade with wooclap server
+ * @throws dml_exception
+ * @throws moodle_exception
+ * TODO check, if possible, if V3 upgrade already performed on remote Wooclap
+ */
+function mod_wooclap_v3_upgrade(wooclap_curl $curl){
+    global $DB;
+    $curl = new wooclap_curl();
+    $headers = [];
+    $headers[0] = "Content-Type: application/json";
+    $headers[1] = "X-Wooclap-PluginVersion: " . get_config('mod_wooclap')->version;
+    $curl->setHeader($headers);
+    $ts = get_isotime();
+    try {
+        $accesskeyid = get_config('wooclap', 'accesskeyid');
+        $version = get_config('mod_wooclap')->version;
+        $baseurl = get_config('wooclap', 'baseurl');
+    } catch (Exception $exc) {
+        echo $exc->getMessage();
+    }
+    $hastrailingslash = substr($baseurl, -1) === '/';
+    // STEP 1.
+    $v3upgradestep1url = $baseurl . ($hastrailingslash ? '' : '/') . 'api/moodle/v3/upgrade-step-1';
+    $step1datatoken = [
+        'accessKeyId' => $accesskeyid,
+        'ts' => $ts,
+        'version' => $version,
+    ];
+
+    $curl_data_step1 = new StdClass;
+    $curl_data_step1->accessKeyId = $accesskeyid;
+    $curl_data_step1->ts = $ts;
+    $curl_data_step1->token = wooclap_generate_token(
+        'V3_UPGRADE_STEP_1?' . wooclap_http_build_query($step1datatoken)
+    );
+    $curl_data_step1->version = $version;
+
+    $response = $curl->get(
+        $v3upgradestep1url . '?' . wooclap_http_build_query($curl_data_step1)
+    );
+    $curlinfo = $curl->info;
+
+    if ($response && is_array($curlinfo) && $curlinfo['http_code'] == 200) {
+        // STEP 2.
+        $idstousernamesmapping = [];
+
+        foreach (json_decode($response) as $moodleuserid) {
+            $user = $DB->get_record(
+                'user',
+                ['id' => $moodleuserid]
+            );
+
+            $idstousernamesmapping[$moodleuserid] = $user->username;
+        }
+
+        $jsonmapping = json_encode($idstousernamesmapping);
+
+        $v3upgradestep2url = $baseurl . ($hastrailingslash ? '' : '/') . 'api/moodle/v3/upgrade-step-2';
+        $step2datatoken = [
+            'accessKeyId' => $accesskeyid,
+            'idsToUsernamesMapping' => $jsonmapping,
+            'ts' => $ts,
+            'version' => $version,
+        ];
+
+        $curl_data_step2 = new StdClass;
+        $curl_data_step2->accessKeyId = $accesskeyid;
+        $curl_data_step2->idsToUsernamesMapping = $jsonmapping;
+        $curl_data_step2->ts = $ts;
+        $curl_data_step2->token = wooclap_generate_token(
+            'V3_UPGRADE_STEP_2?' . wooclap_http_build_query($step2datatoken)
+        );
+        $curl_data_step2->version = $version;
+
+        $response = $curl->post(
+            $v3upgradestep2url, json_encode($curl_data_step2)
+        );
+        $curlinfo = $curl->info;
+
+        if (!$response || !is_array($curlinfo) || $curlinfo['http_code'] != 200) {
+            print_error('error-couldnotperformv3upgradestep2', 'wooclap');
+        }
+    } else {
+        print_error('error-couldnotperformv3upgradestep1', 'wooclap');
+    }
+}


### PR DESCRIPTION
Hello,
since I need to upgrade wooclap on my multiple moodle instances, sharing same code  but not always using wooclap plugin
I try to make a patch to enable upgrade when accesskey is empty
This will avoid moodle upgrade to execute all the remote wooclap v3 upgrade webservices 
I add a cli script that enable an admin to execute the v3 remote upgrade instructions later
May be adding a possibility to detect if remote wooclap v3 upgrade was already made should be a great improvement

Feel free to review my code, it is just a suggestion

Regards
Céline