### PR TITLE
Rename wooclap_update_grades function fixes #20.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -380,7 +380,7 @@ function wooclap_validate_callback_url($callbackurl) {
  * @return bool
  * @throws dml_exception
  */
-function wooclap_update_grade($wooclap, $userid, $gradeval, $completionstatus) {
+function wooclap_update_grades($wooclap, $userid, $gradeval, $completionstatus) {
     global $CFG, $DB;
     require_once($CFG->libdir . '/gradelib.php');
 

--- a/report_wooclap_v3.php
+++ b/report_wooclap_v3.php
@@ -67,7 +67,7 @@ if ($token === $tokencalc) {
     // Find user from username.
     $userdb = $DB->get_record('user', ['username' => $username], 'id', MUST_EXIST);
 
-    $gradestatus = wooclap_update_grade($wooclapinstance, $userdb->id, $score, $completionparam);
+    $gradestatus = wooclap_update_grades($wooclapinstance, $userdb->id, $score, $completionparam);
 
     // COMPLETION_COMPLETE: The user has completed this activity.
     // It is not specified whether they have passed or failed it.


### PR DESCRIPTION
That was reported in #20. This fix here addresses it.