### PR TITLE
2023121300

### DIFF
--- a/report_wooclap_v3.php
+++ b/report_wooclap_v3.php
@@ -39,40 +39,36 @@ $accesskeyid = required_param('accessKeyId', PARAM_TEXT);
 $ts = required_param('ts', PARAM_TEXT);
 $token = required_param('token', PARAM_TEXT);
 
-try {
-    $datatoken = [
-        'accessKeyId' => get_config('wooclap', 'accesskeyid'),
-        'completion' => $completion,
-        'moodleUsername' => $username,
-        'score' => $score,
-        'ts' => $ts,
-    ];
-    $tokencalc = wooclap_generate_token('REPORTv3?' . wooclap_http_build_query($datatoken));
+$datatoken = [
+    'accessKeyId' => get_config('wooclap', 'accesskeyid'),
+    'completion' => $completion,
+    'moodleUsername' => $username,
+    'score' => $score,
+    'ts' => $ts,
+];
+$tokencalc = wooclap_generate_token('REPORTv3?' . wooclap_http_build_query($datatoken));
 
-    if ($token === $tokencalc) {
-        if ($completion == 'passed') {
-            $completionparam = COMPLETION_COMPLETE_PASS;
-        } else if ($completion == 'incomplete') {
-            $completionparam = COMPLETION_INCOMPLETE;
-        } else {
-            $completionparam = COMPLETION_COMPLETE_FAIL;
-        }
-
-        $cm = get_coursemodule_from_id('wooclap', $cmid);
-        $course = get_course($cm->course);
-        $wooclapinstance = wooclap_get_instance($cm->instance);
-
-        // Find user from username.
-        $userdb = $DB->get_record('user', ['username' => $username], 'id', MUST_EXIST);
-
-        $gradestatus = wooclap_update_grade($wooclapinstance, $userdb->id, $score, $completionparam);
-
-        $completion = new completion_info($course);
-        $completion->update_state($cm, $completionparam, $userdb->id);
+if ($token === $tokencalc) {
+    if ($completion == 'passed') {
+        $completionparam = COMPLETION_COMPLETE_PASS;
+    } else if ($completion == 'incomplete') {
+        $completionparam = COMPLETION_INCOMPLETE;
     } else {
-        throw new \moodle_exception('error-invalidtoken', 'wooclap');
-        header("HTTP/1.0 403");
+        $completionparam = COMPLETION_COMPLETE_FAIL;
     }
-} catch (Exception $e) {
-    throw new \moodle_exception('error-couldnotupdatereport', 'wooclap');
+
+    $cm = get_coursemodule_from_id('wooclap', $cmid);
+    $course = get_course($cm->course);
+    $wooclapinstance = wooclap_get_instance($cm->instance);
+
+    // Find user from username.
+    $userdb = $DB->get_record('user', ['username' => $username], 'id', MUST_EXIST);
+
+    $gradestatus = wooclap_update_grade($wooclapinstance, $userdb->id, $score, $completionparam);
+
+    $completion = new completion_info($course);
+    $completion->update_state($cm, $completionparam, $userdb->id);
+} else {
+    throw new \moodle_exception('error-invalidtoken', 'wooclap');
+    header("HTTP/1.0 403");
 }

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2023103100;
+$plugin->version = 2023121300;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
### Problem
We have a few universities which have grade syncing problems when using our Moodle plugin.
We don't know what's happening because the code has a very generic try-catch that throws a very generic error when it catches any error.

### Solution
Remove the try-catch to let Moodle handle the error.
Instead of displaying the very generic "could not update report" error, it now displays the entire error with its stack-trace.