### PR TITLE
2023121801

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -19,6 +19,7 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="wooclapeventid" TYPE="text" LENGTH="small" NOTNULL="false" SEQUENCE="false" COMMENT="Wooclap ID of the event from which this activity was duplicated (if any)"/>
         <FIELD NAME="linkedwooclapeventslug" TYPE="text" LENGTH="small" NOTNULL="false" SEQUENCE="false" COMMENT="Wooclap slug of the event related to the activity"/>
+        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" UNSIGNED="false" COMMENT="This corresponds to the maximum grading; if it's 0, it means that the activity cannot be graded."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -125,5 +125,16 @@ function xmldb_wooclap_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021050100, 'wooclap');
     }
 
+    if ($oldversion < 2023101900) {
+        $table = new xmldb_table('wooclap');
+        $field = new xmldb_field('grade', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '100', null);
+
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2023101900, 'wooclap');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -125,7 +125,7 @@ function xmldb_wooclap_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021050100, 'wooclap');
     }
 
-    if ($oldversion < 2023101900) {
+    if ($oldversion < 2023121801) {
         $table = new xmldb_table('wooclap');
         $field = new xmldb_field('grade', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '100', null);
 
@@ -133,7 +133,7 @@ function xmldb_wooclap_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        upgrade_mod_savepoint(true, 2023101900, 'wooclap');
+        upgrade_mod_savepoint(true, 2023121801, 'wooclap');
     }
 
     return true;

--- a/mod_form.php
+++ b/mod_form.php
@@ -144,6 +144,9 @@ class mod_wooclap_mod_form extends moodleform_mod {
         $mform->setType('wooclapeventid', PARAM_TEXT);
         $mform->setDefault('wooclapeventid', 'none');
 
+        // Set standard grading options in the activity form.
+        $this->standard_grading_coursemodule_elements();
+
         // Set default options.
         $this->standard_coursemodule_elements();
 

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2023121300;
+$plugin->version = 2023121801;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
## Description 

- Added the field `grade` to `mdl_wooclap` tables. if grade is = 0 there will be no grading, if > 0 this be will the max point.
- update of `wooclap_grade_item_update` to handle all grading type.
- migration from existing version to add the field grade with a default of 100 as before it was the only usecase

Other cleanup:
- In all other `mod` from moodle the params of the function is the name of the plugin so here `$wooclap` (e.g lti mod has params  is `$lti`, assign mod has param `$assign` ) 
- simplify the create and update of activities we didn't need to create a new object.

ℹ️  took example on LTI moodle mod for all those changes above: https://github.com/moodle/moodle/blob/23b86254d3182bb7cef45aa755a7a06a5d03faaa/mod/lti/lib.php#L555 

![image](https://github.com/wooclap/moodle-mod_wooclap/assets/1071962/8196a8ac-22c3-4da6-aebb-91fb658b0402)
