### PR TITLE
2024020900

### DIFF
--- a/backup/moodle2/backup_wooclap_stepslib.php
+++ b/backup/moodle2/backup_wooclap_stepslib.php
@@ -42,7 +42,7 @@ class backup_wooclap_activity_structure_step extends backup_activity_structure_s
             "introformat", "editurl", "quiz",
             "authorid", "customcompletion", "timecreated",
             "timemodified", "wooclapeventid",
-            "linkedwooclapeventslug",
+            "linkedwooclapeventslug", "grade",
         ));
 
         $completions = new backup_nested_element('completions');

--- a/db/install.xml
+++ b/db/install.xml
@@ -19,7 +19,7 @@
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="wooclapeventid" TYPE="text" LENGTH="small" NOTNULL="false" SEQUENCE="false" COMMENT="Wooclap ID of the event from which this activity was duplicated (if any)"/>
         <FIELD NAME="linkedwooclapeventslug" TYPE="text" LENGTH="small" NOTNULL="false" SEQUENCE="false" COMMENT="Wooclap slug of the event related to the activity"/>
-        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" UNSIGNED="false" COMMENT="This corresponds to the maximum grading; if it's 0, it means that the activity cannot be graded."/>
+        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="100" SEQUENCE="false" UNSIGNED="false" COMMENT="This corresponds to the maximum grading; if it's 0, it means that the activity cannot be graded."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/lang/en/wooclap.php
+++ b/lang/en/wooclap.php
@@ -52,6 +52,7 @@ $string['showconsentscreen-description'] = 'If active, Wooclap will ask particip
 
 $string['nowooclap'] = 'There are no Wooclap instances';
 $string['customcompletion'] = 'Completion state updated only by Wooclap';
+$string['customcompletion_help'] = 'If enabled, the activity is considered as complete when a student has interacted with at least one Wooclap question.';
 $string['customcompletiongroup'] = 'Wooclap custom completion';
 
 // Consent screen.

--- a/lang/fr/wooclap.php
+++ b/lang/fr/wooclap.php
@@ -50,6 +50,7 @@ $string['baseurl-description'] = 'Sert uniquement au débogage ou au test. Ne mo
 
 $string['nowooclap'] = 'Il n\'y a pas d\'instance Wooclap';
 $string['customcompletion'] = 'Suivi d\'achèvement mis à jour uniquement par Wooclap';
+$string['customcompletion_help'] = 'Si cette option est active, l\'activité est considérée comme terminée lorsqu\'un élève a répondu à au moins une question Wooclap.';
 $string['customcompletiongroup'] = 'Conditions de suivi d\'achèvement Wooclap';
 
 // Consent screen.

--- a/report_wooclap_v3.php
+++ b/report_wooclap_v3.php
@@ -50,10 +50,13 @@ $tokencalc = wooclap_generate_token('REPORTv3?' . wooclap_http_build_query($data
 
 if ($token === $tokencalc) {
     if ($completion == 'passed') {
+        // Passed: >50% score
         $completionparam = COMPLETION_COMPLETE_PASS;
     } else if ($completion == 'incomplete') {
+        // Incomplete: participant hasn't answered all the (correctable) questions
         $completionparam = COMPLETION_INCOMPLETE;
     } else {
+        // Failed: <50% score
         $completionparam = COMPLETION_COMPLETE_FAIL;
     }
 
@@ -66,8 +69,10 @@ if ($token === $tokencalc) {
 
     $gradestatus = wooclap_update_grade($wooclapinstance, $userdb->id, $score, $completionparam);
 
+    // COMPLETION_COMPLETE: The user has completed this activity.
+    // It is not specified whether they have passed or failed it.
     $completion = new completion_info($course);
-    $completion->update_state($cm, $completionparam, $userdb->id);
+    $completion->update_state($cm, COMPLETION_COMPLETE, $userdb->id);
 } else {
     throw new \moodle_exception('error-invalidtoken', 'wooclap');
     header("HTTP/1.0 403");

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2023121801;
+$plugin->version = 2024020900;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
We've improved the completion options coherence by disallowing to check both Wooclap's custom completion and any other method of completion.

Additionally, we've fixed a bug where the rule behind activity completion was incorrect; we now always calculate a user's completion of the activity by checking for any answer (correct or incorrect) to the event.

Finally, we've also fixed the backup & restore issue related to the activity's grade option which was not correctly saved in the backup, and therefore threw an error during restore.