### PR TITLE
2024042200

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -54,7 +54,7 @@ class provider implements
      * @param collection $items a reference to the collection to use to store the metadata.
      * @return collection the updated collection of metadata items.
      */
-    public static function get_metadata(collection $collection) {
+    public static function get_metadata(collection $collection): collection {
 
         $collection->add_external_location_link('wooclap_server', [
             'userid' => 'privacy:metadata:wooclap_server:userid',
@@ -69,7 +69,7 @@ class provider implements
      * @param int $userid the userid.
      * @return contextlist the list of contexts containing user info for the user.
      */
-    public static function get_contexts_for_userid($userid) {
+    public static function get_contexts_for_userid(int $userid): contextlist {
         $contextlist = new \core_privacy\local\request\contextlist();
 
         // First add wooclap activity created by the user.

--- a/mod_form.php
+++ b/mod_form.php
@@ -209,7 +209,7 @@ class mod_wooclap_mod_form extends moodleform_mod {
      *
      * @return array Array of string IDs of added items, empty array if none
      */
-    public function add_completiongrade_rules() {
+    public function add_completiongrade_rules(): array {
         return [];
     }
 

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024041900;
+$plugin->version = 2024042200;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
# Description

Revert back a fix related to PHP incompatibility issue because it was breaking newer version of Moodle, namely 4.3.

This release will drop support for Moodle versions below 3.4.