### PR TITLE
fix: remove unnecessary require that breaks on Moodle 4.4

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -396,7 +396,7 @@ function wooclap_update_grade($wooclap, $userid, $gradeval, $completionstatus) {
         'itemtype' => 'mod',
         'itemmodule' => 'wooclap',
         'iteminstance' => $wooclap->id,
-        'itemnumber' => 0
+        'itemnumber' => 0,
     ];
     if ($gradeitem = grade_item::fetch($params)) {
         $maxgrade = $gradeitem->grademax;
@@ -675,7 +675,7 @@ function wooclap_load_questions_for_v4($quizid) {
                         [
                             'component' => 'mod_quiz',
                             'questionarea' => 'slot',
-                            'quizid' => $quizid
+                            'quizid' => $quizid,
                         ]
                     );
     return $questions;

--- a/lib.php
+++ b/lib.php
@@ -33,7 +33,6 @@ defined('MOODLE_INTERNAL') || die;
 global $CFG;
 require_once($CFG->dirroot . '/mod/wooclap/classes/wooclap_curl.php');
 require_once($CFG->dirroot . '/question/editlib.php');
-require_once($CFG->dirroot . '/question/export_form.php');
 require_once($CFG->dirroot . '/mod/wooclap/format.php');
 
 /**
@@ -397,7 +396,7 @@ function wooclap_update_grade($wooclap, $userid, $gradeval, $completionstatus) {
         'itemtype' => 'mod',
         'itemmodule' => 'wooclap',
         'iteminstance' => $wooclap->id,
-        'itemnumber' => 0,
+        'itemnumber' => 0
     ];
     if ($gradeitem = grade_item::fetch($params)) {
         $maxgrade = $gradeitem->grademax;
@@ -676,7 +675,7 @@ function wooclap_load_questions_for_v4($quizid) {
                         [
                             'component' => 'mod_quiz',
                             'questionarea' => 'slot',
-                            'quizid' => $quizid,
+                            'quizid' => $quizid
                         ]
                     );
     return $questions;

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024042200;
+$plugin->version = 2024052700;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
This PR fixes the issue that causes the plugin to break when being installed on a Moodle 4.4 instance.

The root cause is an unnecessary file that is being required in lib.php. The file was deprecated and has been removed in Moodle 4.4, and therefore now causes a crash.