### PR TITLE
2024070400

### DIFF
--- a/auth_wooclap.php
+++ b/auth_wooclap.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * User Authentication endpoint

--- a/classes/event/course_module_instance_list_viewed.php
+++ b/classes/event/course_module_instance_list_viewed.php
@@ -26,6 +26,9 @@ namespace mod_wooclap\event;
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Course module instance list viewed event handling.
+ */
 class course_module_instance_list_viewed extends \core\event\course_module_instance_list_viewed {
     // No need for any code here as everything is handled by the parent class.
 }

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -270,4 +270,60 @@ class mod_wooclap_observer {
             );
         }
     }
+
+    /**
+     * Updates the gradebook item and the Wooclap event when the activity is updated (ex. when name is changed).
+     * @param \core\event\course_module_updated $event
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws moodle_exception
+     */
+    public static function course_module_updated(\core\event\course_module_updated $event) {
+        global $DB;
+
+        $context = $event->get_context();
+
+        // Get the activity from the database.
+        $cm = get_coursemodule_from_id('wooclap', $event->contextinstanceid, 0, false, MUST_EXIST);
+        $instance = $DB->get_record($cm->modname, array('id' => $cm->instance), '*', MUST_EXIST);
+
+        // Update the grade item name.
+        $gradeitem = $DB->get_record('grade_items', array('iteminstance' => $cm->instance, 'itemmodule' => $cm->modname), '*', MUST_EXIST);
+        if ($gradeitem) {
+            $gradeitem->itemname = $instance->name;
+            $DB->update_record('grade_items', $gradeitem);
+        }
+
+        // Update the name within Wooclap
+        self::rename_wooclap_event($instance->linkedwooclapeventslug, $instance->name);
+    }
+
+    private static function rename_wooclap_event($slug, $name) {
+        $data = new StdClass;
+
+        $data->slug = $slug;
+        $data->name = $name;
+        $data->accessKeyId = get_config('wooclap', 'accesskeyid');
+        $data->ts = wooclap_get_isotime();
+        $data->version = get_config('mod_wooclap')->version;
+
+        $data->token = wooclap_generate_token(
+            'RENAME?' . wooclap_http_build_query($data)
+        );
+
+        // Make an HTTP request to the API to request a RENAME.
+        $curl = new wooclap_curl();
+
+        $headers = [];
+        $headers[0] = "Content-Type: application/json";
+        $headers[1] = "X-Wooclap-PluginVersion: " . get_config('mod_wooclap')->version;
+        $curl->setHeader($headers);
+
+        try {
+            $curl->post(wooclap_get_rename_url(), json_encode($data));
+        } catch (Exception $e) {
+            echo $e->getMessage();
+            return;
+        }
+    }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -36,13 +36,22 @@ require_once($CFG->libdir . '/filelib.php');
 // So we polyfill it.
 
 if (interface_exists('\core_privacy\local\request\userlist')) {
+    /**
+     * Interface for Wooclap UserList, extending core_privacy's UserList.
+     */
     interface wooclap_userlist extends \core_privacy\local\request\userlist {
     }
 } else {
+    /**
+     * Interface for Wooclap UserList
+     */
     interface wooclap_userlist {
     };
 }
 
+/**
+ * Provider class for userlist.
+ */
 class provider implements
         \core_privacy\local\metadata\provider,
         wooclap_userlist,

--- a/classes/wooclap_curl.php
+++ b/classes/wooclap_curl.php
@@ -24,6 +24,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/filelib.php');
 
+/**
+ * Helper class for CURL GET requests.
+ */
 class wooclap_curl extends curl {
     /**
      * HTTP GET method override for PHP_QUERY_RFC3986

--- a/db/events.php
+++ b/db/events.php
@@ -30,8 +30,13 @@ $observers = [
     [
         'eventname' => '\core\event\user_loggedin',
         'callback' => 'mod_wooclap_observer::user_loggedin',
-    ], [
+    ],
+    [
         'eventname' => '\core\event\course_module_created',
         'callback' => 'mod_wooclap_observer::course_module_created',
+    ],
+    [
+        'eventname' => '\core\event\course_module_updated',
+        'callback' => 'mod_wooclap_observer::course_module_updated',
     ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -20,6 +20,9 @@ defined('MOODLE_INTERNAL') || die;
 
 require_once(__DIR__ .  '/../locallib.php');
 
+/**
+ * Runs the required migrations given the previous "oldversion".
+ */
 function xmldb_wooclap_upgrade($oldversion) {
     global $CFG, $DB, $OUTPUT;
 

--- a/format.php
+++ b/format.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * Export wooclap quiz as Moodle XML.

--- a/lang/en/wooclap.php
+++ b/lang/en/wooclap.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * This file contains en_utf8 translation of the Wooclap module

--- a/lang/fr/wooclap.php
+++ b/lang/fr/wooclap.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * This file contains en_utf8 translation of the Wooclap module

--- a/lib.php
+++ b/lib.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * This file contains a library of functions and constants for the wooclap module
@@ -164,6 +163,15 @@ function wooclap_get_ping_url() {
     $baseurl = get_config('wooclap', 'baseurl');
     $hastrailingslash = substr($baseurl, -1) === '/';
     return $baseurl . ($hastrailingslash ? '' : '/') . 'api/moodle/v3/ping';
+}
+
+/**
+ * @return string
+ */
+function wooclap_get_rename_url() {
+    $baseurl = get_config('wooclap', 'baseurl');
+    $hastrailingslash = substr($baseurl, -1) === '/';
+    return $baseurl . ($hastrailingslash ? '' : '/') . 'api/integration/moodle-plugin/rename-event';
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -13,8 +13,8 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
-// More info: https://docs.moodle.org/dev/Upgrade_API .
+
+// More info: https://docs.moodle.org/dev/Upgrade_API.
 
 defined('MOODLE_INTERNAL') || die;
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * @package mod_wooclap

--- a/rename_activity.php
+++ b/rename_activity.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Endpoint to rename a Moodle activity.
+ *
+ * @package    mod_wooclap
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No login check is expected here because this script is called from wooclap
+// ...and we authenticate request with a token.
+
+// @codingStandardsIgnoreLine
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->dirroot . '/mod/wooclap/lib.php');
+
+// Data required to rename the activity.
+$cmid = required_param('cmid', PARAM_INT);
+$name = required_param('name', PARAM_TEXT);
+
+// Data required to authenticate the request.
+$ts = required_param('ts', PARAM_TEXT);
+$token = required_param('token', PARAM_TEXT);
+
+$datatoken = [
+    'accessKeyId' => get_config('wooclap', 'accesskeyid'),
+    'cmid' => $cmid,
+    'name' => $name,
+    'ts' => $ts,
+];
+$tokencalc = wooclap_generate_token('RENAME?' . wooclap_http_build_query($datatoken));
+
+try {
+    if ($token !== $tokencalc) {
+        throw new \moodle_exception('error-couldnotrename', 'wooclap');
+        header("HTTP/1.0 403");
+    }
+
+    // Get the activity from the database.
+    $cm = get_coursemodule_from_id('wooclap', $cmid, 0, false, MUST_EXIST);
+    $instance = $DB->get_record($cm->modname, array('id' => $cm->instance), '*', MUST_EXIST);
+
+    // Update the activity name.
+    $instance->name = $name;
+    $DB->update_record($cm->modname, $instance);
+
+    // Also update the name in the grade book, if it exists.
+    $gradeitem = $DB->get_record('grade_items', array('iteminstance' => $cm->instance, 'itemmodule' => $cm->modname), '*', MUST_EXIST);
+    if ($gradeitem) {
+        $gradeitem->itemname = $name;
+        $DB->update_record('grade_items', $gradeitem);
+    }
+
+    // Clear the course cache for the change to be visible immediately.
+    rebuild_course_cache($cm->course, true);
+} catch (Exception $exc) {
+    throw new \moodle_exception('error-couldnotrename', 'wooclap');
+    header("HTTP/1.0 400");
+}

--- a/report_wooclap.php
+++ b/report_wooclap.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * Completion and grade update endpoint

--- a/report_wooclap_v3.php
+++ b/report_wooclap_v3.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * Completion and grade update endpoint

--- a/settings.php
+++ b/settings.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * @package mod_wooclap

--- a/version.php
+++ b/version.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * @package mod_wooclap
@@ -23,6 +22,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024052700;
+$plugin->version = 2024070400;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';

--- a/view.php
+++ b/view.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * @package mod_wooclap

--- a/wooclap_consent_screen.php
+++ b/wooclap_consent_screen.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 /**
  * Consent screen

--- a/wooclap_consent_screen.tpl.php
+++ b/wooclap_consent_screen.tpl.php
@@ -13,7 +13,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-//
 
 defined('MOODLE_INTERNAL') || die();
 ?>


### PR DESCRIPTION
This PR implements title syncing for Moodle activities and their linked Wooclap event.

Renaming an activity from Moodle will both update the linked gradebook item, as well as update the Wooclap event's name.
Renaming an event from within Wooclap will also update both its linked Moodle activity name as well as its gradebook item.

Additionally, we have updated the moodle-cs package and applied linting changes to match the code standard.