### PR TITLE
2024080900

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -72,7 +72,7 @@ class mod_wooclap_observer {
      * @throws require_login_exception
      */
     public static function course_module_created(\core\event\course_module_created $event) {
-        global $CFG, $DB, $USER;
+        global $CFG, $DB, $USER, $OUTPUT;
 
         if ($event->other['modulename'] !== 'wooclap') {
             return;
@@ -206,9 +206,10 @@ class mod_wooclap_observer {
         $curlinfo = $curl->info;
 
         if (!$response || !is_array($curlinfo) || $curlinfo['http_code'] !== 200) {
-            echo "Error during CREATEv3 Wooclap API call";
             // If CREATE call ends in error, delete this instance.
             wooclap_delete_instance($event->other['instanceid']);
+
+            \core\notification::error(get_string('error-during-quiz-import', 'wooclap'));
             return;
         }
 

--- a/lang/en/wooclap.php
+++ b/lang/en/wooclap.php
@@ -34,6 +34,7 @@ $string['wooclapname'] = 'Name';
 $string['wooclapintro'] = 'Description';
 $string['modulenamepluralformatted'] = 'List of Wooclap activities';
 $string['quiz'] = 'Import a Moodle quiz';
+$string['importquiz_help'] = 'Not all Moodle Quiz questions are supported on Wooclap. Click [here](https://docs.google.com/spreadsheets/d/1qNfegWe99EBQD2Sv2HEDD2i2cC1OVM-x1H9E2ZWliA4/edit?gid=0#gid=0) to find out more information about the question compatibility between the two platforms.';
 $string['wooclapeventid'] = 'Duplicate a Wooclap event';
 
 // Settings.
@@ -79,6 +80,7 @@ $string['error-couldnotperformv3upgradestep1'] = 'Could not perform Step 1 of th
 $string['error-couldnotperformv3upgradestep2'] = 'Could not perform Step 2 of the V3 Upgrade';
 $string['error-reportdeprecated'] = 'report_wooclap.php is deprecated. Use report_wooclap_v3.php instead.';
 $string['error-invalidtoken'] = 'Invalid token';
+$string['error-during-quiz-import'] = 'The Quiz cannot be converted into Wooclap questions because it only contains questions that are not compatible with Wooclap.';
 $string['error-invalidjoinurl'] = 'Invalid join URL';
 $string['error-missingparameters'] = 'Missing parameters';
 $string['error-invalid-callback-url'] = 'The callback URL provided does not match the baseurl domain name defined in the settings.';

--- a/lang/fr/wooclap.php
+++ b/lang/fr/wooclap.php
@@ -34,6 +34,7 @@ $string['wooclapname'] = 'Nom de l\'activité';
 $string['wooclapintro'] = 'Description de l\'activité';
 $string['modulenamepluralformatted'] = 'Liste des activités Wooclap';
 $string['quiz'] = 'Importer un quiz Moodle';
+$string['importquiz_help'] = 'Tous les types de questions des tests Moodle ne sont pas pris en charge sur Wooclap. Cliquez [ici](https://docs.google.com/spreadsheets/d/1qNfegWe99EBQD2Sv2HEDD2i2cC1OVM-x1H9E2ZWliA4/edit?gid=0#gid=0) pour en savoir plus sur la compatibilité des questions entre les deux plateformes.';
 $string['wooclapeventid'] = 'Dupliquer un événement Wooclap';
 
 // Settings.
@@ -76,6 +77,7 @@ $string['error-couldnotloadevents'] = 'Impossible de charger les événements Wo
 $string['error-couldnotupdatereport'] = 'Impossible de mettre à jour le rapport';
 $string['error-couldnotauth'] = 'Impossible d\'obtenir l\'utilisateur ou le cours durant l\'authentication';
 $string['error-invalidtoken'] = 'Le valeur du paramètre "token" est invalide';
+$string['error-during-quiz-import'] = 'Le test ne peut pas être converti en questions Wooclap car il ne contient que des questions non compatibles avec Wooclap.';
 $string['error-invalidjoinurl'] = 'L\'URL pour rejoindre l\'événement est invalide';
 $string['error-missingparameters'] = 'Paramètres manquants';
 $string['error-reportdeprecated'] = 'report_wooclap.php n\'est plus supporté. Veuiller plutôt utiliser report_wooclap_v3.php.';

--- a/mod_form.php
+++ b/mod_form.php
@@ -77,6 +77,11 @@ class mod_wooclap_mod_form extends moodleform_mod {
             $quizz[$quizdb->id] = $quizdb->name;
         }
         $mform->addElement('select', 'quiz', get_string('quiz', 'wooclap'), $quizz);
+        $mform->addHelpButton(
+            'quiz',
+            'importquiz',
+            'wooclap'
+        );
         $mform->setType('quiz', PARAM_INT);
         if ($quizid > 0) {
             $mform->setDefault('quiz', $quizid);

--- a/version.php
+++ b/version.php
@@ -23,6 +23,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024052700;
+$plugin->version = 2024080900;
 $plugin->requires = 2016112900;
 $plugin->component = 'mod_wooclap';


### PR DESCRIPTION
# Release notes

We've fixed an issue occurring when importing a Moodle quiz with only invalid questions; it now correctly archives the Wooclap event as well as deleting the Moodle activity. A new error banner is now displayed when this happens for improved clarity.

![Screenshot 2024-08-09 at 14 45 03](https://github.com/user-attachments/assets/10a08f83-cbb8-40d0-986b-68fc7f6d95fd)

Additionally, we've added a helper tooltip next to the Moodle quiz import setting of a new activity form, explaining that some Moodle quiz questions cannot be imported in a Wooclap event. A Google Sheet link containing an in-depth explanation has been added. 

![Screenshot 2024-08-09 at 14 45 23](https://github.com/user-attachments/assets/7ab74959-a56e-4115-9d9d-3e8a5cdeb2f0)
