### PR TITLE
Fix inconsitencies with language strings

### DIFF
--- a/lang/en/wooclap.php
+++ b/lang/en/wooclap.php
@@ -32,7 +32,7 @@ $string['pluginadministration'] = 'Wooclap administration';
 $string['wooclapname'] = 'Name';
 $string['wooclapintro'] = 'Description';
 $string['modulenamepluralformatted'] = 'List of Wooclap activities';
-$string['quiz'] = 'Import a Moodle quiz';
+$string['importquiz'] = 'Import a Moodle quiz';
 $string['importquiz_help'] = 'Not all Moodle Quiz questions are supported on Wooclap. Click [here](https://docs.google.com/spreadsheets/d/1qNfegWe99EBQD2Sv2HEDD2i2cC1OVM-x1H9E2ZWliA4/edit?gid=0#gid=0) to find out more information about the question compatibility between the two platforms.';
 $string['wooclapeventid'] = 'Duplicate a Wooclap event';
 

--- a/lang/fr/wooclap.php
+++ b/lang/fr/wooclap.php
@@ -32,7 +32,7 @@ $string['pluginadministration'] = 'Administration Wooclap';
 $string['wooclapname'] = 'Nom de l\'activité';
 $string['wooclapintro'] = 'Description de l\'activité';
 $string['modulenamepluralformatted'] = 'Liste des activités Wooclap';
-$string['quiz'] = 'Importer un quiz Moodle';
+$string['importquiz'] = 'Importer un quiz Moodle';
 $string['importquiz_help'] = 'Tous les types de questions des tests Moodle ne sont pas pris en charge sur Wooclap. Cliquez [ici](https://docs.google.com/spreadsheets/d/1qNfegWe99EBQD2Sv2HEDD2i2cC1OVM-x1H9E2ZWliA4/edit?gid=0#gid=0) pour en savoir plus sur la compatibilité des questions entre les deux plateformes.';
 $string['wooclapeventid'] = 'Dupliquer un événement Wooclap';
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -75,7 +75,7 @@ class mod_wooclap_mod_form extends moodleform_mod {
         foreach ($quizzdb as $quizdb) {
             $quizz[$quizdb->id] = $quizdb->name;
         }
-        $mform->addElement('select', 'quiz', get_string('quiz', 'wooclap'), $quizz);
+        $mform->addElement('select', 'quiz', get_string('importquiz', 'wooclap'), $quizz);
         $mform->addHelpButton(
             'quiz',
             'importquiz',


### PR DESCRIPTION
There are language inconsitencies. In mod_form.php there are the methods used:
$mform->addElement()
$mform->addHelpButton()
once with the language string "quiz" and once with "importquiz".

This leads to these warnings:

Whoops \ Exception \ ErrorException (E_USER_NOTICE)
Help title string does not exist: [importquiz, wooclap]

Stack frames (7)
6 debugging
…/lib/classes/output/help_icon.php76
5 core\output\help_icon diag_strings
…/lib/classes/output/core_renderer.php2117
4 core\output\core_renderer help_icon
…/lib/formslib.php2388
3 MoodleQuickForm addHelpButton
…/mod/wooclap/mod_form.php79
2 mod_wooclap_mod_form definition
…/lib/formslib.php217
1 moodleform __construct
…/course/moodleform_mod.php127
0 moodleform_mod __construct
…/course/modedit.php157


Whoops \ Exception \ ErrorException (E_USER_NOTICE)
Invalid get_string() identifier: 'quiz' or component 'wooclap'. Perhaps you are missing $string['quiz'] = ''; in mod/wooclap/lang/en/wooclap.php?

Stack frames (6)
5 debugging
…/lib/classes/string_manager_standard.php355
4 core_string_manager_standard get_string
…/lib/moodlelib.php7001
3 get_string
…/mod/wooclap/mod_form.php78
2 mod_wooclap_mod_form definition
…/lib/formslib.php217
1 moodleform __construct
…/course/moodleform_mod.php127
0 moodleform_mod __construct
…/course/modedit.php157

I renamed the language string to importquiz (that makes sense IMHO because importquiz_help exists as well).