### PR TITLE
ci: add Trivy security scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,3 +17,4 @@ jobs:
     secrets:
       app-id: ${{ secrets.DEVX_APP_ID }}
       app-private-key: ${{ secrets.DEVX_APP_PRIVATE_KEY }}
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,19 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main, master, staging, production]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  trivy:
+    uses: wooclap/devx/.github/workflows/trivy.yml@latest
+    secrets:
+      app-id: ${{ secrets.DEVX_APP_ID }}
+      app-private-key: ${{ secrets.DEVX_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What is this?

This PR adds a [Trivy](https://github.com/aquasecurity/trivy) security scan workflow that runs on PRs and pushes to main/staging.

It uses the shared reusable workflow from `wooclap/devx` to scan for vulnerabilities and secrets.

## What to review

- The workflow triggers on `pull_request`, `push` to main/staging, and `workflow_dispatch`
- It requires `DEVX_APP_ID` and `DEVX_APP_PRIVATE_KEY` secrets to be available in this repo